### PR TITLE
Fix build of uuseg.cmxs

### DIFF
--- a/src/uuseg.mldylib
+++ b/src/uuseg.mldylib
@@ -1,0 +1,7 @@
+Uuseg_base
+Uuseg_buf
+Uuseg_grapheme_cluster
+Uuseg_word
+Uuseg_sentence
+Uuseg_line_break
+Uuseg


### PR DESCRIPTION
File `uuseg.mldylib` is needed for that. Otherwise, only `uuseg.cmx` is included in the library.